### PR TITLE
Fix onError() throwing if err is undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const retrier = require("./retry");
+const retrier = require('./retry');
 
 function retry(fn, opts) {
   function run(resolve, reject) {
@@ -17,11 +17,11 @@ function retry(fn, opts) {
     // would be futile (e.g.: auth errors)
 
     function bail(err) {
-      reject(err || new Error("Aborted"));
+      reject(err || new Error('Aborted'));
     }
 
     function onError(err, num) {
-      if (err.bail) {
+      if (err === Object(err) && err.bail) {
         bail(err);
         return;
       }


### PR DESCRIPTION
While it's not very nice thing to do, it's totally allowed by
ECMA-262 to call `Promise.reject()` with an argument that is not
an instance of `Error`. If this happens inside a promise that
`async-retry-ng` is awaiting for then `onRetry()` might throw
depending on the exact type of the `reason` argument. Therefore
`onRetry()` should first check that `reason` is of expected type.

Fixes #4